### PR TITLE
Moved antlr-runtime OSGi dependency to jstyleparser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,6 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <dependency>
-        <groupId>org.apache.servicemix.bundles</groupId>
-        <artifactId>org.apache.servicemix.bundles.antlr-runtime</artifactId>
-        <version>3.5.2_1</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   
@@ -49,14 +44,6 @@
     <dependency>
       <groupId>org.daisy.libs</groupId>
       <artifactId>jstyleparser</artifactId>
-    </dependency>
-    <!--
-        OSGi runtime dependencies
-    -->
-    <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.antlr-runtime</artifactId>
-      <scope>runtime</scope>
     </dependency>
     <!--
         test dependencies


### PR DESCRIPTION
This PR is part of https://github.com/daisy/pipeline/pull/503.

Depends on:
- [x] https://github.com/daisy/jStyleParser/pull/10
